### PR TITLE
Added PIP dependencies caching in sphinx-multidoc workflow

### DIFF
--- a/.github/workflows/sphinx-multidoc.yml
+++ b/.github/workflows/sphinx-multidoc.yml
@@ -39,18 +39,13 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt', 'docs/requirements.txt') }}
+          key: ${{ runner.os }}-pip-key-${{ hashFiles('requirements.txt') }}
 
-      # Install PIP dependencies (if not cached)
+      # Install PIP dependencies
       - name: Install PIP dependencies
-        if: steps.pip-dependencies.outputs.cache-hit != 'true'
         run: |
           pip install -r requirements.txt
           pip install -r docs/requirements.txt
-
-      # Install additional dependencies (that cannot be cached)
-      - name: Install additional dependencies
-        run: |
           pip install git+https://github.com/samtygier-stfc/sphinx-multiversion.git@prebuild_command
 
       # Build versioned documentation


### PR DESCRIPTION
- PIP dependencies should now be cached (up to ~5GiB according to actions/cache)
- sphinx-multidoc workflow should now produce documentation correctly for tags