### PR TITLE
Issue#33

### DIFF
--- a/deeprob/torch/base.py
+++ b/deeprob/torch/base.py
@@ -11,6 +11,8 @@ from torch import distributions
 class ProbabilisticModel(abc.ABC, nn.Module):
     """Abstract Probabilistic Model base class."""
 
+    has_rsample = False
+
     def log_prob(self, x: torch.Tensor) -> torch.Tensor:
         """
         Compute the log-likelihood of a batched sample.

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -25,6 +25,13 @@ def assert_flow_inverse(flow, data):
     assert torch.allclose(orig_data, data, atol=5e-7)
 
 
+def assert_sampling_autograd(flow):
+    with torch.enable_grad():
+        samples = flow.rsample(64)
+        assert samples.requires_grad
+        samples.mean().backward()
+
+
 def test_squeeze_depth2d(data):
     squeezed_data = squeeze_depth2d(data)
     unsqueezed_data = unsqueeze_depth2d(squeezed_data)
@@ -66,6 +73,7 @@ def test_realnvp1d(flattened_data):
         dequantize=True, logit=0.01
     ).eval()
     assert_flow_inverse(realnvp, flattened_data)
+    assert_sampling_autograd(realnvp)
 
 
 def test_realnvp2d(data):
@@ -82,6 +90,7 @@ def test_realnvp2d(data):
         dequantize=True, logit=0.01
     ).eval()
     assert_flow_inverse(realnvp, data)
+    assert_sampling_autograd(realnvp)
 
 
 def test_maf(flattened_data):
@@ -98,3 +107,4 @@ def test_maf(flattened_data):
         dequantize=True, logit=0.01
     ).eval()
     assert_flow_inverse(maf, flattened_data)
+    assert_sampling_autograd(maf)


### PR DESCRIPTION
1. Introduced ```rsample``` method to normalizing flows models for differentiable sampling.
2. Backpropagating through autoregressive layers (MAFs) in forward mode is now possible, i.e., see ```__backprop_apply_forward``` method.