### PR TITLE
Add implementations for cutset networks (CNets)

### DIFF
--- a/deeprob/spn/learning/cnet_bayesian.py
+++ b/deeprob/spn/learning/cnet_bayesian.py
@@ -1,0 +1,320 @@
+from __future__ import annotations
+from typing import Optional, List
+
+import numpy as np
+from scipy.special import gammaln
+
+from deeprob.utils.statistics import compute_prior_counts, compute_joint_counts, estimate_priors_joints_bayesian
+from deeprob.spn.structure.cltree import BinaryCLT
+from deeprob.spn.structure.cnet import BinaryCNet
+
+
+def compute_or_bd_scores(
+    data: np.ndarray,
+    ess: float = 0.1,
+    fracs: np.ndarray = None
+):
+    n_samples, n_features = data.shape
+    if fracs is not None:
+        n_samples = np.sum(fracs)
+    prior_counts = compute_prior_counts(data=data, fracs=fracs)
+    alpha_i = ess
+    alpha_ik = ess / 2
+    log_gamma_nodes = gammaln(alpha_i) - gammaln(n_samples + alpha_i) \
+                      + np.sum(gammaln(prior_counts + alpha_ik) - gammaln(alpha_ik), axis=-1)
+    return log_gamma_nodes
+
+
+def compute_clt_bd_scores(
+    data: np.ndarray,
+    ess: float = 0.1,
+    fracs: np.ndarray = None
+):
+    joint_counts = compute_joint_counts(data=data, fracs=fracs)
+    alpha_ij = ess / 2
+    alpha_ijk = ess / (2 * 2)
+    parent_counts = np.sum(joint_counts, axis=-2)
+    log_gamma_pairs = gammaln(alpha_ij) - gammaln(parent_counts + alpha_ij) \
+                      + np.sum(gammaln(joint_counts + alpha_ijk) - gammaln(alpha_ijk), axis=-2)
+    return np.sum(log_gamma_pairs, axis=-1)
+
+
+def estimate_clt_params_bayesian(
+    clt: BinaryCLT,
+    data: np.ndarray,
+    ess: float = 0.1,
+    fracs: np.ndarray = None
+):
+    n_samples, n_features = data.shape
+    priors, joints = estimate_priors_joints_bayesian(data, ess=ess, fracs=fracs)
+
+    vs = np.arange(n_features)
+    params = np.einsum('ikl,il->ilk', joints[vs, clt.tree], np.reciprocal(priors[clt.tree]))
+    params[clt.root] = priors[clt.root]
+
+    # Re-normalize the factors, because there can be FP32 approximation errors
+    params /= np.sum(params, axis=2, keepdims=True)
+    return np.log(params)
+
+
+def eval_tree_score(
+    tree: Optional[List[int], np.ndarray],
+    clt_scores: np.ndarray,
+    or_scores: np.ndarray
+):
+    root_idx = tree.argmin()
+    parent_indices_no_root = np.delete(tree, obj=root_idx)
+    child_indices_no_root = np.delete(np.arange(len(tree)), obj=root_idx)
+    return np.sum(clt_scores[child_indices_no_root, parent_indices_no_root]) + or_scores[root_idx]
+
+
+def select_cand_cuts(
+    data: np.ndarray,
+    ess: float = 0.1,
+    n_cand_cuts: int = 10,
+    fracs: np.ndarray = None
+):
+    # Compute the counts
+    n_samples, n_features = data.shape
+    if fracs is not None:
+        n_samples = np.sum(fracs)
+    counts_features = data.sum(axis=0) if fracs is None else (data.T * fracs).T.sum(axis=0)
+
+    prior_counts = compute_prior_counts(data, fracs=fracs)
+    joint_counts = compute_joint_counts(data, fracs=fracs)
+    smoothing_joint, smoothing_prior = ess / 2, ess
+    if ess < 0.01:
+        prior_counts = prior_counts.astype(np.float64)
+        joint_counts = joint_counts.astype(np.float64)
+    log_priors = np.log(prior_counts + smoothing_joint) - np.log(n_samples + smoothing_prior)
+    mean_entropy = -(log_priors * np.exp(log_priors)).sum() / n_features
+
+    conditionals = np.empty((n_features, n_features, 2, 2), dtype=prior_counts.dtype)
+    conditionals[:, :, 0, 0] = ((joint_counts[:, :, 0, 0] + smoothing_joint).T /
+                                (prior_counts[:, 0] + smoothing_prior)).T
+    conditionals[:, :, 0, 1] = ((joint_counts[:, :, 0, 1] + smoothing_joint).T /
+                                (prior_counts[:, 0] + smoothing_prior)).T
+    conditionals[:, :, 1, 0] = ((joint_counts[:, :, 1, 0] + smoothing_joint).T /
+                                (prior_counts[:, 1] + smoothing_prior)).T
+    conditionals[:, :, 1, 1] = ((joint_counts[:, :, 1, 1] + smoothing_joint).T /
+                                (prior_counts[:, 1] + smoothing_prior)).T
+
+    vs = np.repeat(np.arange(n_features)[None, :], n_features, axis=0)
+    vs = vs[~np.eye(vs.shape[0], dtype=bool)].reshape(vs.shape[0], -1)
+    parents = np.repeat(np.arange(n_features)[:, None], n_features - 1, axis=1)
+
+    ratio_features = counts_features / n_samples
+    entropies = ratio_features * \
+                np.mean(-np.sum(conditionals[parents, vs, 1, :] * np.log(conditionals[parents, vs, 1, :]), axis=-1),
+                        axis=1) + \
+                (1 - ratio_features) * \
+                np.mean(-np.sum(conditionals[parents, vs, 0, :] * np.log(conditionals[parents, vs, 0, :]), axis=-1),
+                        axis=1)
+
+    info_gains = mean_entropy - entropies
+    selected_idx = np.argmax(info_gains) if n_cand_cuts == 1 else np.argpartition(info_gains,
+                                                                                  -n_cand_cuts)[-n_cand_cuts:]
+    return selected_idx
+
+
+def learn_cnet_bd(
+    data: np.ndarray,
+    ess: float = 0.1,
+    n_cand_cuts: int = 10,
+):
+    """
+    Learn a binary CNet using the Bayesian-Dirichlet equivalent uniform (BDeu) score.
+
+    :param cnet: The binary CNet.
+    :param data: The training data.
+    :param ess: The equivalent sample size (ESS).
+    :param n_cand_cuts: The number of candidate cut nodes.
+    :return: A binary CNet.
+    """
+    n_samples, n_features = data.shape
+    root = BinaryCNet(scope=list(range(n_features)))
+    root.assign_indices(row_indices=np.arange(n_samples), col_indices=np.arange(n_features))
+    root.fit_clt(data=data)
+    # use Bayesian posterior parameters.
+    root.clt.params = estimate_clt_params_bayesian(clt=root.clt, data=data, ess=ess)
+    or_score_matrix = compute_or_bd_scores(data=data, ess=ess)
+    clt_score_matrix = compute_clt_bd_scores(data=data, ess=ess)
+    clt_score = eval_tree_score(tree=root.clt.tree, clt_scores=clt_score_matrix, or_scores=or_score_matrix)
+
+    node_stack = [[root, ess, clt_score]]
+    while node_stack:
+        node, node_ess, node_clt_score = node_stack.pop(0)
+        if len(node.scope) == 1:
+            continue
+
+        partition = data[node.row_indices][:, node.col_indices]
+        or_score_matrix = compute_or_bd_scores(data=partition, ess=node_ess)
+
+        k = min(n_cand_cuts, len(node.scope))
+        search_indices = select_cand_cuts(data=partition, ess=node_ess, n_cand_cuts=k)
+
+        best_or_idx = -1
+        best_cnet_score = -np.inf
+        best_left_clt = None
+        best_right_clt = None
+        best_left_clt_score = -np.inf
+        best_right_clt_score = -np.inf
+
+        for i in search_indices:
+            left_row_indices = node.row_indices[partition[:, i] == 0]
+            right_row_indices = node.row_indices[partition[:, i] == 1]
+
+            if len(left_row_indices) == 0 or len(right_row_indices) == 0:
+                continue
+
+            child_col_indices = np.delete(node.col_indices, obj=i)
+            left_partition = data[left_row_indices][:, child_col_indices]
+            right_partition = data[right_row_indices][:, child_col_indices]
+            new_scope = node.scope.copy()
+            del new_scope[i]
+
+            left_clt = BinaryCLT(scope=new_scope)
+            left_or_score_matrix = compute_or_bd_scores(data=left_partition, ess=node_ess / 2)
+            left_clt_score_matrix = compute_clt_bd_scores(data=left_partition, ess=node_ess / 2)
+
+            right_clt = BinaryCLT(scope=new_scope)
+            right_or_score_matrix = compute_or_bd_scores(data=right_partition, ess=node_ess / 2)
+            right_clt_score_matrix = compute_clt_bd_scores(data=right_partition, ess=node_ess / 2)
+
+            left_clt.fit(data=left_partition, domain=[[0, 1]] * len(new_scope), alpha=0.01)
+            right_clt.fit(data=right_partition, domain=[[0, 1]] * len(new_scope), alpha=0.01)
+
+            left_clt.params = estimate_clt_params_bayesian(left_clt, data=left_partition, ess=node_ess / 2)
+            right_clt.params = estimate_clt_params_bayesian(right_clt, data=right_partition, ess=node_ess / 2)
+
+            left_clt_score = eval_tree_score(tree=left_clt.tree,
+                                             clt_scores=left_clt_score_matrix,
+                                             or_scores=left_or_score_matrix)
+            right_clt_score = eval_tree_score(tree=right_clt.tree,
+                                              clt_scores=right_clt_score_matrix,
+                                              or_scores=right_or_score_matrix)
+            cnet_score = left_clt_score + right_clt_score + or_score_matrix[i]
+
+            if cnet_score > best_cnet_score:
+                best_cnet_score = cnet_score
+                best_or_idx = i
+                best_left_clt = left_clt
+                best_right_clt = right_clt
+                best_left_clt_score = left_clt_score
+                best_right_clt_score = right_clt_score
+
+        if best_cnet_score > node_clt_score:
+            node.or_id = node.scope[best_or_idx]
+            node.clt = None
+            left_row_indices = node.row_indices[partition[:, best_or_idx] == 0]
+            right_row_indices = node.row_indices[partition[:, best_or_idx] == 1]
+            child_col_indices = np.delete(node.col_indices, obj=best_or_idx)
+            left_weight = (len(left_row_indices) + node_ess / 2) / (len(node.row_indices) + node_ess)
+            right_weight = 1 - left_weight
+            new_scope = node.scope.copy()
+            del new_scope[best_or_idx]
+
+            left_child = BinaryCNet(scope=new_scope)
+            left_child.clt = best_left_clt
+            left_child.assign_indices(row_indices=left_row_indices, col_indices=child_col_indices)
+            right_child = BinaryCNet(scope=new_scope)
+            right_child.clt = best_right_clt
+            right_child.assign_indices(row_indices=right_row_indices, col_indices=child_col_indices)
+
+            node_stack.append([left_child, node_ess / 2, best_left_clt_score])
+            node_stack.append([right_child, node_ess / 2, best_right_clt_score])
+            node.weights = [left_weight, right_weight]
+            node.children = [left_child, right_child]
+    return root
+
+
+def learn_cnet_bic(
+    data: np.ndarray,
+    alpha: float = 0.01,
+    n_cand_cuts: int = 10,
+):
+    n_samples, n_features = data.shape
+    root = BinaryCNet(scope=list(range(n_features)))
+    root.assign_indices(row_indices=np.arange(n_samples), col_indices=np.arange(n_features))
+    root.fit_clt(data=data)
+    clt_score = np.sum(root.clt.log_likelihood(data)) - 0.5 * np.log(n_samples) * (2 * n_features - 1)
+
+    node_stack = [[root, clt_score]]
+    while node_stack:
+        node, node_clt_score = node_stack.pop(0)
+        if len(node.scope) == 1:
+            continue
+
+        partition = data[node.row_indices][:, node.col_indices]
+
+        k = min(n_cand_cuts, len(node.scope))
+        search_indices = select_cand_cuts(partition, ess=4 * alpha, n_cand_cuts=k)
+
+        best_or_idx = -1
+        best_cnet_score = -np.inf
+        best_left_clt = None
+        best_right_clt = None
+        best_left_clt_score = 0.0
+        best_right_clt_score = 0.0
+        for i in search_indices:
+            left_row_indices = node.row_indices[partition[:, i] == 0]
+            right_row_indices = node.row_indices[partition[:, i] == 1]
+
+            if len(left_row_indices) == 0 or len(right_row_indices) == 0:
+                continue
+
+            child_col_indices = np.delete(node.col_indices, obj=i)
+            left_partition = data[left_row_indices][:, child_col_indices]
+            right_partition = data[right_row_indices][:, child_col_indices]
+            new_scope = node.scope.copy()
+            del new_scope[i]
+
+            left_weight = (len(left_row_indices) + alpha) / (len(node.row_indices) + 2 * alpha)
+            right_weight = 1 - left_weight
+
+            left_clt = BinaryCLT(scope=new_scope)
+            right_clt = BinaryCLT(scope=new_scope)
+
+            left_clt.fit(data=left_partition, domain=[[0, 1]] * len(new_scope), alpha=alpha)
+            right_clt.fit(data=right_partition, domain=[[0, 1]] * len(new_scope), alpha=alpha)
+
+            left_clt_score = np.sum(left_clt.log_likelihood(left_partition)) \
+                             - 0.5 * np.log(len(data)) * (2 * len(new_scope) - 1)
+            right_clt_score = np.sum(right_clt.log_likelihood(right_partition)) \
+                              - 0.5 * np.log(len(data)) * (2 * len(new_scope) - 1)
+            or_score = len(left_partition) * np.log(left_weight) + len(right_partition) * np.log(right_weight) \
+                       - 0.5 * np.log(len(data))
+            cnet_score = left_clt_score + right_clt_score + or_score
+
+            if cnet_score > best_cnet_score:
+                best_cnet_score = cnet_score
+                best_or_idx = i
+                best_left_clt = left_clt
+                best_right_clt = right_clt
+                best_left_clt_score = left_clt_score
+                best_right_clt_score = right_clt_score
+
+        if best_cnet_score > node_clt_score:
+            node.or_id = node.scope[best_or_idx]
+            node.clt = None
+            left_row_indices = node.row_indices[partition[:, best_or_idx] == 0]
+            right_row_indices = node.row_indices[partition[:, best_or_idx] == 1]
+            child_col_indices = np.delete(node.col_indices, obj=best_or_idx)
+
+            left_weight = (len(left_row_indices) + alpha) / (len(node.row_indices) + 2 * alpha)
+            right_weight = 1 - left_weight
+            new_scope = node.scope.copy()
+            del new_scope[best_or_idx]
+
+            left_child = BinaryCNet(scope=new_scope)
+            left_child.clt = best_left_clt
+            left_child.assign_indices(row_indices=left_row_indices, col_indices=child_col_indices)
+            right_child = BinaryCNet(scope=new_scope)
+            right_child.clt = best_right_clt
+            right_child.assign_indices(row_indices=right_row_indices, col_indices=child_col_indices)
+
+            node_stack.append([left_child, best_left_clt_score])
+            node_stack.append([right_child, best_right_clt_score])
+            node.weights = [left_weight, right_weight]
+            node.children = [left_child, right_child]
+    return root

--- a/deeprob/spn/structure/cnet.py
+++ b/deeprob/spn/structure/cnet.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+from typing import Optional, Union, List
+
+import copy
+import numpy as np
+
+from deeprob.utils.statistics import compute_prior_counts, compute_joint_counts
+from deeprob.spn.structure.node import Node
+from deeprob.spn.structure.cltree import BinaryCLT
+
+
+class ORNode(Node):
+    def __init__(
+        self,
+        scope: Optional[List[int]] = None,
+        children: Optional[List[Node]] = None,
+        weights: Optional[Union[List[float], np.ndarray]] = None,
+        or_id: Optional[int] = None
+    ):
+        """
+        Initialize an OR node given weights, child instances and child nodes.
+
+        :param scope: The scope of the OR node.
+        :param children: The child nodes of the OR node.
+        :param weights: The weights of the OR node.
+        :param or_id: The id of the OR node.
+        """
+        if weights is not None:
+            if isinstance(weights, list):
+                weights = np.array(weights, dtype=np.float32)
+            if not np.isclose(np.sum(weights), 1.0):
+                raise ValueError("Weights don't sum up to 1")
+        self.weights = weights
+        self.or_id = or_id
+        self.row_indices = None
+        self.col_indices = None
+        self.clt = None
+
+        super().__init__(scope, children)
+
+    def assign_indices(
+        self,
+        row_indices: Optional[List[int], np.ndarray],
+        col_indices: Optional[List[int], np.ndarray]
+    ):
+        """
+        Assign the corresponding indices of the OR node's partition in the original data set.
+
+        :param row_indices: Row indices of the partition.
+        :param col_indices: Column indices of the partition.
+        :return:
+        """
+        self.row_indices = row_indices
+        self.col_indices = col_indices
+
+    def likelihood(self, x: np.ndarray) -> np.ndarray:
+        pass
+
+    def log_likelihood(self, x: np.ndarray) -> np.ndarray:
+        pass
+
+
+class BinaryCNet(ORNode):
+    def __init__(
+        self,
+        scope: Optional[List[int]] = None,
+        children: Optional[List[Node]] = None,
+        weights: Optional[Union[List[float], np.ndarray]] = None,
+        or_id: Optional[int] = None
+    ):
+        """
+        Initialize a binary cutset network (CNet).
+
+        :param scope: The scope of the binary CNet.
+        :param children: The child OR nodes of the binary CNet.
+        :param weights: The weights of the current OR node.
+        :param or_id: The id of the current OR node.
+        """
+        super().__init__(scope, children, weights, or_id)
+
+    def fit(
+        self,
+        data: np.ndarray,
+        alpha: float = 0.01,
+        min_n_samples: int = 10,
+        min_n_features: int = 1,
+        min_mean_entropy: float = 0.01
+    ):
+        """
+        Fit the structure and the MLE parameters given some training data and hyper-parameters.
+
+        :param data: The training data.
+        :param alpha: The Laplace smoothing factor.
+        :param min_n_samples: The minimum number of samples to split.
+        :param min_n_features: The minimum number of features to split.
+        :param min_mean_entropy: The minimum mean entropy of RVs given the data to split.
+        :return:
+        """
+        n_samples, n_features = data.shape
+        self.scope = list(range(n_features))
+        self.assign_indices(row_indices=np.arange(n_samples), col_indices=np.arange(n_features))
+        root = BinaryCNet(scope=list(range(n_features)))
+        root.assign_indices(row_indices=np.arange(n_samples), col_indices=np.arange(n_features))
+        node_stack = [root]
+        while node_stack:
+            node = node_stack.pop(0)
+            partition = data[node.row_indices][:, node.col_indices]
+            n_samples, n_features = partition.shape
+            if n_samples <= min_n_samples or n_features <= min_n_features:
+                # stopped due to few samples or features
+                node.fit_clt(data=partition, alpha=alpha)
+                continue
+            best_or_idx, mean_entropy, max_info_gain = self.__select_variable_entropy(partition, alpha=alpha)
+            if mean_entropy < min_mean_entropy or max_info_gain <= 0:
+                # stopped due to small entropy or negative information gain
+                node.fit_clt(data=partition, alpha=alpha)
+                continue
+            left_row_indices = node.row_indices[partition[:, best_or_idx] == 0]
+            right_row_indices = node.row_indices[partition[:, best_or_idx] == 1]
+            child_col_indices = np.delete(node.col_indices, obj=best_or_idx)
+            left_weight = (len(left_row_indices) + alpha) / (len(node.row_indices) + 2 * alpha)
+            right_weight = 1 - left_weight
+            new_scope = node.scope.copy()
+            del new_scope[best_or_idx]
+            left_child = BinaryCNet(scope=new_scope)
+            left_child.assign_indices(row_indices=left_row_indices, col_indices=child_col_indices)
+            right_child = BinaryCNet(scope=new_scope)
+            right_child.assign_indices(row_indices=right_row_indices, col_indices=child_col_indices)
+            node_stack.append(left_child)
+            node_stack.append(right_child)
+            node.children = [left_child, right_child]
+            node.weights = [left_weight, right_weight]
+            node.or_id = node.scope[best_or_idx]
+        self.or_id = root.or_id
+        self.children = root.children
+        self.weights = root.weights
+
+    def fit_clt(
+        self,
+        data: np.ndarray,
+        alpha: float = 0.01
+    ):
+        """
+        Fit a Binary CLT for the RVs in the scope of the current OR node.
+
+        :param data: The data partition.
+        :param alpha: The laplace smoothing factor.
+        :return:
+        """
+        clt = BinaryCLT(scope=self.scope)
+        clt.fit(data=data, domain=[[0, 1]] * len(self.scope), alpha=alpha)
+        self.clt = clt
+
+    @staticmethod
+    def __select_variable_entropy(
+        data: np.ndarray,
+        alpha: float = 0.01
+    ):
+        """
+        Select the best cut node based on the reduced entropy (information gain).
+
+        :param data: The training data partition.
+        :param alpha: The Laplace smoothing factor.
+        :return: The index of the selected RV,
+                 the mean entropy of the RVs in the partition,
+                 the information gain of the selected RV.
+        """
+        n_samples, n_features = data.shape
+        counts_features = np.sum(data, axis=0)
+
+        prior_counts = compute_prior_counts(data)
+        joint_counts = compute_joint_counts(data)
+        priors = (prior_counts + 2 * alpha) / (n_samples + 4 * alpha)
+        priors[:, 0] = 1.0 - priors[:, 1]
+        mean_entropy = -(priors * np.log(priors)).sum() / n_features
+
+        conditionals = np.empty((n_features, n_features, 2, 2), dtype=np.float32)
+        # as we are computing the probabilities for all nodes after cutting on a node,
+        # the laplace smoothing factor is essentially the same as computing general prior probabilities
+        conditionals[:, :, 0, 0] = ((joint_counts[:, :, 0, 0] + 2 * alpha).T / (prior_counts[:, 0] + 4 * alpha)).T
+        conditionals[:, :, 0, 1] = ((joint_counts[:, :, 0, 1] + 2 * alpha).T / (prior_counts[:, 0] + 4 * alpha)).T
+        conditionals[:, :, 1, 0] = ((joint_counts[:, :, 1, 0] + 2 * alpha).T / (prior_counts[:, 1] + 4 * alpha)).T
+        conditionals[:, :, 1, 1] = ((joint_counts[:, :, 1, 1] + 2 * alpha).T / (prior_counts[:, 1] + 4 * alpha)).T
+
+        vs = np.repeat(np.arange(n_features)[None, :], n_features, axis=0)
+        vs = vs[~np.eye(vs.shape[0], dtype=bool)].reshape(vs.shape[0], -1)
+        parents = np.repeat(np.arange(n_features)[:, None], n_features - 1, axis=1)
+
+        ratio_features = counts_features / n_samples
+        entropies = ratio_features * \
+                    np.mean(-np.sum(conditionals[parents, vs, 1, :] * np.log(conditionals[parents, vs, 1, :]), axis=-1),
+                            axis=1) + \
+                    (1 - ratio_features) * \
+                    np.mean(-np.sum(conditionals[parents, vs, 0, :] * np.log(conditionals[parents, vs, 0, :]), axis=-1),
+                            axis=1)
+        info_gains = mean_entropy - entropies
+        selected_idx = np.argmax(info_gains)
+        return selected_idx, mean_entropy, info_gains[selected_idx]
+
+    def __is_leaf(self):
+        """
+        Check if the current OR node is a leaf.
+
+        :return: True if the OR node has fitted a binary CLT, otherwise False
+        """
+        return True if self.clt else False
+
+    def likelihood(self, x: np.ndarray) -> np.ndarray:
+        return np.exp(self.log_likelihood(x))
+
+    def log_likelihood(self, x: np.ndarray) -> np.ndarray:
+        n_samples, n_features = x.shape
+        root = copy.copy(self)
+        root.row_indices, root.col_indices = np.arange(n_samples), np.arange(n_features)
+        node_stack = [root]
+        log_likes = np.zeros(n_samples)
+        while node_stack:
+            node = node_stack.pop(0)
+            partition = x[node.row_indices][:, node.col_indices]
+            if node.__is_leaf():
+                log_likes[node.row_indices] += node.clt.log_likelihood(partition).squeeze()
+                continue
+            node_idx = node.scope.index(node.or_id)
+            left_child = copy.copy(node.children[0])
+            right_child = copy.copy(node.children[1])
+            left_child.row_indices = node.row_indices[partition[:, node_idx] == 0]
+            right_child.row_indices = node.row_indices[partition[:, node_idx] == 1]
+            log_likes[left_child.row_indices] += np.log(node.weights[0])
+            log_likes[right_child.row_indices] += np.log(node.weights[1])
+            left_child.col_indices = np.delete(node.col_indices, obj=node_idx)
+            right_child.col_indices = np.delete(node.col_indices, obj=node_idx)
+            node_stack.append(left_child)
+            node_stack.append(right_child)
+        return log_likes

--- a/deeprob/utils/statistics.py
+++ b/deeprob/utils/statistics.py
@@ -217,3 +217,48 @@ def compute_joint_counts(
     joint_counts[:, :, 1, 0] = counts_rows - counts_ones
     joint_counts[:, :, 1, 1] = counts_ones
     return joint_counts
+
+
+def estimate_priors_joints_bayesian(
+    data: np.ndarray,
+    ess: float = 0.1,
+    fracs: np.ndarray = None
+):
+    if ess < 0.0:
+        raise ValueError("The ESS must be non-negative")
+
+    # Check the data dtype
+    if data.dtype != np.float32:
+        data = data.astype(np.float32)
+
+    # Compute the counts
+    n_samples, n_features = data.shape
+    if fracs is not None:
+        n_samples = np.sum(fracs)
+    counts_ones = np.dot(data.T, data).astype(np.float64) if fracs is None \
+        else np.dot(data.T * fracs, data).astype(np.float64)
+    counts_features = np.diag(counts_ones).astype(np.float64)
+    counts_cols = (counts_features * np.ones_like(counts_ones)).astype(np.float64)
+    counts_rows = np.transpose(counts_cols).astype(np.float64)
+
+    # Compute the prior probabilities
+    priors = np.empty(shape=(n_features, 2), dtype=np.float64)
+    priors[:, 1] = (counts_features + ess / 2) / (n_samples + ess)
+    priors[:, 0] = 1.0 - priors[:, 1]
+
+    # Compute the joints probabilities
+    joints = np.empty(shape=(n_features, n_features, 2, 2), dtype=np.float64)
+    joints[:, :, 0, 0] = n_samples - counts_cols - counts_rows + counts_ones
+    joints[:, :, 0, 1] = counts_cols - counts_ones
+    joints[:, :, 1, 0] = counts_rows - counts_ones
+    joints[:, :, 1, 1] = counts_ones
+    joints = (joints + ess / 4) / (n_samples + ess)
+
+    # Correct smoothing on the diagonal of joints array
+    idx_features = np.arange(n_features)
+    joints[idx_features, idx_features, 0, 0] = priors[:, 0]
+    joints[idx_features, idx_features, 0, 1] = 0.0
+    joints[idx_features, idx_features, 1, 0] = 0.0
+    joints[idx_features, idx_features, 1, 1] = priors[:, 1]
+
+    return priors, joints


### PR DESCRIPTION
Adding implementations for cutset networks (CNets), including:

- A BinaryCNet class, which implements the classical CNet learning algorithm based on the information gain heuristic from decision tree literature.
- The learning algorithm based on the Bayesian-Dirichlet equivalent uniform (BDeu) score.
- The learning algorithm based on the Bayesian information criterion (BIC) score.
- Functions to compute counts of RVs given some data sets.
- Functions to estimate Bayesian posterior parameters.