### PR TITLE
Fix dataset loading in `clt_plot.py`

### DIFF
--- a/examples/clt_plot.py
+++ b/examples/clt_plot.py
@@ -1,11 +1,14 @@
 import numpy as np
-from sklearn.datasets import load_boston
+import pandas as pd
 
 import deeprob.spn.structure as spn
 
 if __name__ == '__main__':
     # Load the boston dataset and binarize it
-    data, _ = load_boston(return_X_y=True)
+    data_url = "http://lib.stat.cmu.edu/datasets/boston"
+    raw_df = pd.read_csv(data_url, sep="\s+", skiprows=22, header=None)
+    data = np.hstack([raw_df.values[::2, :], raw_df.values[1::2, :2]])
+
     avg_features = np.mean(data, axis=0)
     data = (data < avg_features).astype(np.float32)
     n_samples, n_features = data.shape


### PR DESCRIPTION
`load_boston` was removed from sklearn.
Message from import error for `load_boston` for context:
"""
`load_boston` has been removed from scikit-learn since version 1.2.

The Boston housing prices dataset has an ethical problem: as
investigated in [1], the authors of this dataset engineered a
non-invertible variable "B" assuming that racial self-segregation had a
positive impact on house prices [2]. Furthermore the goal of the
research that led to the creation of this dataset was to study the
impact of air quality but it did not give adequate demonstration of the
validity of this assumption.

The scikit-learn maintainers therefore strongly discourage the use of
this dataset unless the purpose of the code is to study and educate
about ethical issues in data science and machine learning.

In this special case, you can fetch the dataset from the original
source::

    import pandas as pd
    import numpy as np

    data_url = "http://lib.stat.cmu.edu/datasets/boston"
    raw_df = pd.read_csv(data_url, sep="\s+", skiprows=22, header=None)
    data = np.hstack([raw_df.values[::2, :], raw_df.values[1::2, :2]])
    target = raw_df.values[1::2, 2]
"""